### PR TITLE
Inject Core Application as separate utils function

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ $ npm install --save frint-utils
 
 Usage:
 
+
+Creating reducer
+
 ```js
 import { createReducer } from 'frint-utils';
 import * as ActionTypes from '../constants/ActionTypes';
@@ -27,6 +30,16 @@ export const todos = createReducer(initialState, {
     return [...state, action.text];
   }
 });
+```
+
+Creating core application
+
+```js
+import App from './app';
+import config from './config';
+
+const coreApp = new App(config);
+injectCoreApp(coreApp);
 ```
 
 ## License

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
 export createReducer from './createReducer';
+export injectCoreApp from './injectCoreApp';

--- a/src/injectCoreApp.js
+++ b/src/injectCoreApp.js
@@ -1,11 +1,11 @@
 // Core App creator
 
 /**
- * Set core app to window object and protect it's deleting/rewritig
+ * Set core app to window object and protect it's deleting/rewriting
  *
  * @method injectCoreApp
  * @param {Object} App core application
- * @returns {Object} core application object
+ * @returns {void}
  */
 export default function injectCoreApp(coreApp) {
   let app = null;

--- a/src/injectCoreApp.js
+++ b/src/injectCoreApp.js
@@ -1,0 +1,26 @@
+// Core App creator
+
+/**
+ * Set core app to window object and protect it's deleting/rewritig
+ *
+ * @method injectCoreApp
+ * @param {Object} App core application
+ * @returns {Object} core application object
+ */
+export default function injectCoreApp(coreApp) {
+  let app = null;
+
+  Object.defineProperty(window, 'app', {
+    get() {
+      return app;
+    },
+    set(value) {
+      if (app !== null) {
+        throw new Error('Attempt to override root app');
+      }
+      app = value;
+    }
+  });
+
+  window.app = coreApp;
+}

--- a/test/injectCoreApp.spec.js
+++ b/test/injectCoreApp.spec.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+
+import { injectCoreApp } from '../src';
+
+describe('injectCoreApp', function () {
+
+  let windowOld;
+
+  beforeEach(() => {
+    windowOld = global.window;
+    global.window = {};
+  });
+
+  afterEach(() => {
+    global.window = windowOld;
+  });
+
+  it('should set undefined to app if no argumets were provided', function() {
+    injectCoreApp();
+
+    expect(global.window.app).to.eql(undefined);
+  });
+
+  it('should correctly set core application obejct to window.app', function() {
+    const coreObj = { name: 'coreApplication' };
+    injectCoreApp(coreObj);
+
+    expect(global.window.app).to.deep.equal(coreObj);
+  });
+
+  it('should throw an error if window.app instead of rewriting', function() {
+    const coreObj = { name: 'coreApplication'};
+    const coreObjRewrite = { name: 'coreApplication'};
+    injectCoreApp(coreObj);
+    expect(() => global.window.app = coreObjRewrite).to.throw('Attempt to override root app');
+    expect(global.window.app).to.equal(coreObj);
+    expect(global.window.app).to.deep.equal(coreObj);
+  });
+});


### PR DESCRIPTION
InjectedCoreApp is a function to set  the core application object to window.app and protect it for rewrites.

The previous version of this function (createAndInstantiateCoreApp) creates a core application inside the function and the set it to window. The implementation has some violation of design. That's why in utils I extract only set/inject functionality. So the creation of core application should be outside this function.
